### PR TITLE
Don't require composer/composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         }
     },
     "require": {
-        "composer/composer": "1.0.*@dev",
         "symfony/console": "~2.3",
         "symfony/finder": "~2.3",
         "kzykhys/parallel": "dev-master",


### PR DESCRIPTION
This is more of a question. Why did you include such a requirement in the `composer.json` file?

Is there a reason for the version constraint?

If there is no particular use of that, could you remove it?

It is creating some problems. Example: https://travis-ci.org/erusev/parsedown/jobs/18845949
